### PR TITLE
APP_OPTIONS after the -jar doesnt work

### DIFF
--- a/spring-boot/springboot-sti/.sti/bin/run
+++ b/spring-boot/springboot-sti/.sti/bin/run
@@ -7,4 +7,4 @@
 #	https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
 #
 
-exec java -Djava.security.egd=file:/dev/./urandom -jar /opt/openshift/app.jar $APP_OPTIONS
+exec java -Djava.security.egd=file:/dev/./urandom $APP_OPTIONS -jar /opt/openshift/app.jar


### PR DESCRIPTION
Change the order of the command to be able to use the -D option to set properties values to spring.
